### PR TITLE
Clean README for external audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A full-stack application that extracts YouTube video transcripts and generates A
 
 ## 🏗️ Architecture
 
-This project is structured as a monorepo with future React migration in mind:
+This project is structured as a monorepo:
 
 ```
 YouTube_transcript/
 ├── server/          # Express.js API backend
-├── client/          # Frontend (HTML+Tailwind, React-ready)
+├── client/          # Frontend (HTML + Tailwind CSS)
 ├── shared/          # Shared TypeScript types
 ├── render.yaml      # Render.com deployment config
 └── package.json     # Root coordination scripts
@@ -22,7 +22,6 @@ YouTube_transcript/
 - **Recent History**: Quick access to previously processed videos
 - **Modern UI**: Clean, responsive design with Tailwind CSS
 - **Production Ready**: PostgreSQL support and Render deployment
-- **Future Proof**: Structured for easy React migration
 
 ## 🚀 Quick Start
 
@@ -103,22 +102,6 @@ npm start
    npm start
    ```
 
-## 🔄 Future React Migration
-
-The project is structured to easily migrate to React when needed:
-
-1. **Current State**: HTML + Tailwind CSS + Vanilla JS
-2. **Migration Path**: 
-   - Replace `client/public/index.html` with React app
-   - Update `client/package.json` with React dependencies
-   - Use existing shared types in `shared/types/`
-   - Tailwind configuration is already React-ready
-
-3. **Benefits of Current Approach**:
-   - Faster initial development
-   - No build complexity overhead
-   - Easy to understand and maintain
-   - All the benefits of modern CSS (Tailwind)
 
 ## 📝 Environment Variables
 
@@ -140,10 +123,6 @@ The project is structured to easily migrate to React when needed:
 - **Frontend**: HTML, Tailwind CSS, Vanilla JavaScript
 - **AI**: OpenAI GPT API
 
-### Future Ready
-- **Frontend**: React, TypeScript
-- **Build**: Vite
-- **Deployment**: Render.com
 
 ## 📋 API Endpoints
 


### PR DESCRIPTION
## Summary
- trim README content for outside users
- remove roadmap sections about React migration

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686bd06f9f408320a78c973473178e84